### PR TITLE
Separate installs

### DIFF
--- a/build_baselines.py
+++ b/build_baselines.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os.path
 import packer
 import re
+import sh
 import signal
 import sys
 import time
@@ -274,7 +275,11 @@ def build_base(iso, md5, replace_existing, vmServer=None, prependString = ""):
             return p  # just return without exec since ret value is not checked anyways
 
 
-    p.build(parallel=True, debug=False, force=False)
+    try:
+        p.build(parallel=True, debug=False, force=False)
+    except sh.ErrorReturnCode:
+        print "Error: build of " + prependString + vm_name + " returned non-zero"
+        return p
 
     if vmServer is not None:
         vmServer.connect()

--- a/windows_packer.json
+++ b/windows_packer.json
@@ -149,8 +149,7 @@
         "scripts/chocolatey_installs/7zip.bat",
         "scripts/configs/apply_password_settings.bat",
         "scripts/configs/create_users.bat",
-        "scripts/chocolatey_installs/vcredist2008.bat",
-        "scripts/installs/vm-guest-tools.bat"
+        "scripts/chocolatey_installs/vcredist2008.bat"
       ]
     },
     {
@@ -162,9 +161,20 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "scripts/chocolatey_installs/java.bat",
-        "scripts/installs/install_ruby.bat",
+        "scripts/installs/install_ruby.bat"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "windows-shell",
+      "remote_path": "C:/Windows/Temp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
+      "scripts": [
         "scripts/chocolatey_installs/python2.bat",
-        "scripts/chocolatey_installs/python3.bat"
+        "scripts/chocolatey_installs/python3.bat",
+        "scripts/installs/vm-guest-tools.bat"
       ]
     },
     {

--- a/windows_packer.json
+++ b/windows_packer.json
@@ -173,8 +173,7 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "scripts/chocolatey_installs/python2.bat",
-        "scripts/chocolatey_installs/python3.bat",
-        "scripts/installs/vm-guest-tools.bat"
+        "scripts/chocolatey_installs/python3.bat"
       ]
     },
     {
@@ -186,6 +185,7 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "scripts/configs/configure_firewall.bat",
+        "scripts/installs/vm-guest-tools.bat",
         "scripts/configs/packer_cleanup.bat"
       ]
     }


### PR DESCRIPTION
Fix #6, log just print an error for failed vm builds and continue. Address race condition with failures due to vmware tools background update during install sections.