### PR TITLE
suppress auto update for VMware tools

### DIFF
--- a/windows_packer.json
+++ b/windows_packer.json
@@ -42,7 +42,8 @@
         "memsize": "4096",
         "numvcpus": "2",
         "scsi0.virtualDev": "lsisas1068",
-        "virtualHW.version": 10
+        "virtualHW.version": 10,
+        "tools.upgrade.policy": "manual"
       }
     },
     {


### PR DESCRIPTION
Add a configuration option to the vmx that ensures VMware tools do not backgound update after first power cycle.