### PR TITLE
Address python.org requirement for tls12 7/2K8

### DIFF
--- a/scripts/chocolatey_installs/python2.bat
+++ b/scripts/chocolatey_installs/python2.bat
@@ -1,3 +1,5 @@
 chocolatey feature enable -n=allowGlobalConfirmation
+set ChocolateyUrlOverride=http://web.archive.org/web/20180206051312/https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi
+set ChocolateyUrl64bitOverride=http://web.archive.org/web/20180206051312/https://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi
 choco install python --version 2.7.11
 chocolatey feature disable -n=allowGlobalConfirmation


### PR DESCRIPTION
Lets use a fun little hack to proxy and avoid python.org tls 1.2 requirement with *The Wayback Machine*.

This get the python installer from archive.org copy of www.python.org.  Chocolatey still validates the checksum so we can be *fairly* sure we got a safe archive version.