### PR TITLE
update to hosted python2

### DIFF
--- a/scripts/chocolatey_installs/python2.bat
+++ b/scripts/chocolatey_installs/python2.bat
@@ -1,5 +1,5 @@
 chocolatey feature enable -n=allowGlobalConfirmation
-set ChocolateyUrlOverride=http://web.archive.org/web/20180206051312/https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi
-set ChocolateyUrl64bitOverride=http://web.archive.org/web/20180206051312/https://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi
+set ChocolateyUrlOverride=https://baseline-builder.s3.amazonaws.com/python-2.7.11.msi
+set ChocolateyUrl64bitOverride=https://baseline-builder.s3.amazonaws.com/python-2.7.11.amd64.msi
 choco install python --version 2.7.11
 chocolatey feature disable -n=allowGlobalConfirmation


### PR DESCRIPTION
Since the epic archive.org method of retrieval is not reliable, pull from an s3 bucket. :-(