### PR TITLE
Add Windows 10 1809 and Server 2019

### DIFF
--- a/build_baselines.py
+++ b/build_baselines.py
@@ -20,6 +20,7 @@ esxi_file = "esxi_config.json"
 
 def create_autounattend(vm_name, os_parts=None, index="1", prependString=""):
     # Product Keys from http://technet.microsoft.com/en-us/library/jj612867.aspx
+    # Newer keys from https://docs.microsoft.com/en-us/windows-server/get-started/kmsclientkeys
     os_keys = {
         "10": "W269N-WFGWX-YVC9B-4J6C9-T83GX",
         "2003": None,
@@ -29,6 +30,7 @@ def create_autounattend(vm_name, os_parts=None, index="1", prependString=""):
         "2012": "XC9B7-NBPP2-83J2H-RHMBY-92BT4",
         "2012r2": "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
         "2016": "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
+        "2019": "N69G4-B89J2-4G8F4-WWYCC-J464C",
         "7": "FJ82H-XT6CR-J8D7P-XQJJ2-GPDD4",
         "8": "NG4HW-VH26C-733KW-K6F98-J8CK4",
         "8.1": "GCRJD-8NW9H-F2CDX-CCM8D-9D6T9",
@@ -152,6 +154,7 @@ def build_base(iso, md5, replace_existing, vmServer=None, prependString = ""):
         "2012": "windows8srv-64",
         "2012r2": "windows8srv-64",
         "2016": "windows9srv-64",
+        "2019": "windows9srv-64",
         "7": "windows7-64",
         "8": "windows8-64",
         "8.1": "windows8-64",

--- a/iso_list.json
+++ b/iso_list.json
@@ -1,4 +1,6 @@
 {
+    "en_windows_10_consumer_edition_version_1809_updated_sept_2018_x64_dvd_491ea967.iso": "7a19f70f948614b55b716a6ee0ca5274",
+    "en_windows_10_consumer_edition_version_1809_updated_sept_2018_x86_dvd_c5960600.iso": "663e18f44a8e799f538d8c6ed5d4f520",
     "en_windows_10_consumer_editions_version_1803_updated_march_2018_x64_dvd_12063379.iso": "986e2e17cf6b0b49141cd15699768e6e",
     "en_windows_10_consumer_editions_version_1803_updated_march_2018_x86_dvd_12063380.iso": "166d99b85390d58017dc0bef14e5f8eb",
     "en_windows_10_multi-edition_version_1709_updated_sept_2017_x64_dvd_100090817.iso": "5e8bdef20c4b468f868f1f579197f7cf",
@@ -26,6 +28,7 @@
     "en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso": "78bff6565f178ed08ab534397fe44845",
     "en_windows_server_2012_r2_x64_dvd_2707946.iso": "0e7c09aab20dec3cd7eab236dab90e78",
     "en_windows_server_2012_x64_dvd_915478.iso": "da91135483e24689bfdaf05d40301506",
-    "en_windows_server_2016_x64_dvd_9718492.iso": "e02d2e482b0f3dab915435e9040c13b4"
+    "en_windows_server_2016_x64_dvd_9718492.iso": "e02d2e482b0f3dab915435e9040c13b4",
+    "en_windows_server_2019_x64_dvd_4cb967d8.iso": "a876d230944abe3bf2b5c2b40da6c4a3"
 }
 


### PR DESCRIPTION
Add required references to build new baselines for:
  Windows 10 1809 x64
  Windows 10 1809 x86
  Windows Server 2019 x64