### PR TITLE
do not trust default uploaded windows.iso

### DIFF
--- a/scripts/installs/vm-guest-tools.bat
+++ b/scripts/installs/vm-guest-tools.bat
@@ -11,10 +11,6 @@ if %OS%==64BIT echo This is a 64bit operating system
     )
 msiexec /qb /i C:\Windows\Temp\7z1801.msi
 
-if exist "C:\Users\vagrant\windows.iso" (
-    move /Y C:\Users\vagrant\windows.iso C:\Windows\Temp
-)
-
 wmic os get caption | find /i "7" > NUL && set TOOLS_VER=OLD || set TOOLS_VER=NEW
 
 if %TOOLS_VER%==NEW (


### PR DESCRIPTION
Packer in some cases will upload windows.iso from the host
building the VM, since server 2008 needs a specific older
version of tools this can cause problems.

Example issue:
VMware Fusion 11 on macOS Mojave will supply 10.3.x in windows.iso
and will hit https://kb.vmware.com/s/article/55798 due the patch level
expectaions that are intentionally not met for Windows 2008r2.

Found while working on PR https://github.com/rapid7/metasploitable3/pull/358 users
attempting to build on macOS Mojave and targeting local box images instead of ESXi
could encounter build hangs or failures to install vmware-tools on baseline images.