### PR TITLE
update rvm signing key for more compatibility

### DIFF
--- a/msf_host_packer.json
+++ b/msf_host_packer.json
@@ -7,7 +7,7 @@
   "iso_checksum": "ee834fbeb94cc55972b38caafa2029c29625e2e8",
   "iso_checksum_type": "sha1",
   "iso_name": "ubuntu-16.04.4-server-amd64.iso",
-  "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-amd64.iso",
+  "iso_url": "http://old-releases.ubuntu.com/releases/16.04.4/ubuntu-16.04.4-server-amd64.iso",
   "memory": "1024",
   "preseed": "preseed.cfg",
   "ssh_fullname": "msfuser",

--- a/scripts/msf_host/msf_host_setup.sh
+++ b/scripts/msf_host/msf_host_setup.sh
@@ -39,8 +39,9 @@ su ${SSH_USERNAME} -c 'mkdir ~/rapid7 && \
   mkdir -p test_artifacts/test_scripts'
 
 RUBY_VERSION=`cat /home/${SSH_USERNAME}/rapid7/metasploit-framework/.ruby-version`
-su ${SSH_USERNAME} -c "curl -sSL https://rvm.io/mpapis.asc | gpg --import -"
-su ${SSH_USERNAME} -c "/bin/bash -l -c 'curl -sSL https://get.rvm.io | bash -s stable'"
+su ${SSH_USERNAME} -c 'command curl -sSL https://rvm.io/mpapis.asc | gpg --import - && \
+  command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - && \
+  curl -L -sSL https://get.rvm.io | bash -s stable'
 su ${SSH_USERNAME} -c "/bin/bash -l -c 'rvm autolibs disable && \
   rvm install ${RUBY_VERSION} && \
   rvm ${RUBY_VERSION} do gem install bundler --no-rdoc --no-ri && \


### PR DESCRIPTION
Recent changes to the signature used on stable `rvm` installs require an update to a more compatible method of key retrieval.

This update allows `msf_host` builds to successfully complete while retrieving the latest stable version of `rvm`.

Testing:
- [ ] `python build_msf_host.py` successfully completes when targeting esxi or local vmware configurations.