### PR TITLE
enable tls 1.2 in chocolatey install

### DIFF
--- a/scripts/installs/install_chocolatey.ps1
+++ b/scripts/installs/install_chocolatey.ps1
@@ -1,6 +1,0 @@
-$ChocoInstallPath = "$env:SystemDrive\ProgramData\Chocolatey\bin"
-
-if (!(Test-Path $ChocoInstallPath)) {
-  $env:chocolateyVersion = '0.10.8' # hack as 0.10.9 is broken - for https://github.com/chocolatey/choco/issues/1529
-  iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
-}

--- a/windows_packer.json
+++ b/windows_packer.json
@@ -135,7 +135,7 @@
     {
       "type":"powershell",
       "inline": [
-        "$env:chocolateyVersion = '0.10.8'; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+        "$env:chocolateyVersion = '0.10.8'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
       ]
     },
     {


### PR DESCRIPTION
Fix #48 

Use tls 1.2 when attaining the install script.