### PR TITLE
update dotnet 4.5 to restore chocolatey

### DIFF
--- a/answer_files/windows/Autounattend_x64.xml
+++ b/answer_files/windows/Autounattend_x64.xml
@@ -268,7 +268,7 @@
                     <Order>26</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\install_netfx.ps1 -AutoStart</CommandLine>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\install_net45.ps1 -AutoStart</CommandLine>
                     <Description>Install .NET 4.0</Description>
                     <Order>27</Order>
                 </SynchronousCommand>

--- a/answer_files/windows/Autounattend_x86.xml
+++ b/answer_files/windows/Autounattend_x86.xml
@@ -262,7 +262,7 @@
                     <Order>26</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\install_netfx.ps1 -AutoStart</CommandLine>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\install_net45.ps1 -AutoStart</CommandLine>
                     <Description>Install .NET 4.0</Description>
                     <Order>27</Order>
                 </SynchronousCommand>

--- a/scripts/installs/chocolatey.cmd
+++ b/scripts/installs/chocolatey.cmd
@@ -1,1 +1,0 @@
-@powershell -NoProfile -ExecutionPolicy Bypass -File "%systemdrive%\vagrant\scripts\installs\install_chocolatey.ps1"

--- a/scripts/installs/chocolatey.ps1
+++ b/scripts/installs/chocolatey.ps1
@@ -1,0 +1,50 @@
+function Invoke-CLR4PowerShellCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ScriptBlock]
+        $ScriptBlock,
+        
+        [Parameter(ValueFromRemainingArguments=$true)]
+        [Alias('Args')]
+        [object[]]
+        $ArgumentList
+    )
+    
+    if ($PSVersionTable.CLRVersion.Major -eq 4) {
+        Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+        return
+    }
+
+    $RunActivationConfigPath = $Env:TEMP | Join-Path -ChildPath ([Guid]::NewGuid())
+    New-Item -Path $RunActivationConfigPath -ItemType Container | Out-Null
+@"
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0"/>
+  </startup>
+</configuration>
+"@ | Set-Content -Path $RunActivationConfigPath\powershell.exe.activation_config -Encoding UTF8
+
+    $EnvVarName = 'COMPLUS_ApplicationMigrationRuntimeActivationConfigPath'
+    $EnvVarOld = [Environment]::GetEnvironmentVariable($EnvVarName)
+    [Environment]::SetEnvironmentVariable($EnvVarName, $RunActivationConfigPath)
+
+    try {
+        & powershell.exe -inputformat text -command $ScriptBlock -args $ArgumentList
+    } finally {
+        [Environment]::SetEnvironmentVariable($EnvVarName, $EnvVarOld)
+        $RunActivationConfigPath | Remove-Item -Recurse
+    }
+
+}
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Invoke-CLR4PowerShellCommand -ScriptBlock {
+ [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+
+# cribbed from https://gist.github.com/jstangroome/882528

--- a/scripts/installs/chocolatey.ps1
+++ b/scripts/installs/chocolatey.ps1
@@ -43,8 +43,16 @@ function Invoke-CLR4PowerShellCommand {
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-Invoke-CLR4PowerShellCommand -ScriptBlock {
- [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+$isWin8 = wmic os get caption | find /i '" 8 "'
+$isWin2012 = wmic os get caption | find /i '" 2012 "'
+
+# skip wrapping for 8 or 2012?
+if ($isWin8 -or $isWin2012){
+   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+}else{
+    Invoke-CLR4PowerShellCommand -ScriptBlock {
+       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+    }
 }
 
 # cribbed from https://gist.github.com/jstangroome/882528

--- a/scripts/installs/install_net45.ps1
+++ b/scripts/installs/install_net45.ps1
@@ -1,0 +1,23 @@
+$Logfile = "C:\Windows\Temp\dotnet-install.log"
+function LogWrite {
+   Param ([string]$logstring)
+   $now = Get-Date -format s
+   Add-Content $Logfile -value "$now $logstring"
+   Write-Host $logstring
+}
+
+LogWrite "Downloading dotNet 4.5.1"
+try {
+    (New-Object System.Net.WebClient).DownloadFile('http://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe', 'C:\Windows\Temp\dotnet.exe')
+} catch {
+    LogWrite $_.Exception | Format-List -force
+    LogWrite "Failed to download file."
+}
+
+LogWrite "Starting installation process..."
+try {
+    Start-Process -FilePath "C:\Windows\Temp\dotnet.exe" -ArgumentList "/I /q /norestart" -Wait -PassThru
+} catch {
+    LogWrite $_.Exception | Format-List -force
+    LogWrite "Exception during install process."
+}

--- a/scripts/installs/install_netfx.ps1
+++ b/scripts/installs/install_netfx.ps1
@@ -1,7 +1,0 @@
-# setup dotnetfx4
-$netfx_url = "https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe"
-
-Write-Output "Downloading $netfx_url"
-(New-Object System.Net.WebClient).DownloadFile($netfx_url, "C:\Windows\Temp\dotNetFx40_Full_x86_x64.exe")
-Write-Output "Starting Install of dotNetFx40_Full_x86_x64.exe"
-Start-Process "C:\Windows\Temp\dotNetFx40_Full_x86_x64.exe" "/q /norestart" -Wait

--- a/windows_packer.json
+++ b/windows_packer.json
@@ -14,14 +14,13 @@
       "ssh_wait_timeout": "2h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "{{user `guest_os_type`}}",
-      "tools_upload_flavor": "windows",
       "disk_size": 61440,
       "floppy_files": [
         "{{user `autounattend`}}",
         "./scripts/configs/microsoft-updates.bat",
         "./scripts/configs/win-updates.ps1",
         "./scripts/installs/openssh.ps1",
-        "./scripts/installs/install_netfx.ps1",
+        "./scripts/installs/install_net45.ps1",
         "./resources/certs/oracle-cert.cer",
         "./resources/certs/gdig2.crt",
         "./resources/certs/comodorsadomainvalidationsecureserverca.crt",
@@ -67,7 +66,7 @@
         "./scripts/configs/microsoft-updates.bat",
         "./scripts/configs/win-updates.ps1",
         "./scripts/installs/openssh.ps1",
-        "./scripts/installs/install_netfx.ps1",
+        "./scripts/installs/install_net45.ps1",
         "./resources/certs/oracle-cert.cer",
         "./resources/certs/gdig2.crt",
         "./resources/certs/comodorsadomainvalidationsecureserverca.crt",
@@ -134,8 +133,8 @@
     },
     {
       "type":"powershell",
-      "inline": [
-        "$env:chocolateyVersion = '0.10.8'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+      "scripts": [
+        "./scripts/installs/chocolatey.ps1"
       ]
     },
     {


### PR DESCRIPTION
Fixes #48 for more systems.

* install dot net 4.5
* wrap chocolatey install in dotnet 4.x caller
* vmware tools are installed by script