### PR TITLE
Added -f or --factory to all baselines for a clean build

### DIFF
--- a/build_linux_baselines.py
+++ b/build_linux_baselines.py
@@ -12,7 +12,7 @@ from lib import packerMod
 from lib import serverHelper
 
 
-def build_base(packer_var_file, common_vars, packerfile, factory_image, replace_existing, vmServer=None, prependString = ""):
+def build_base(packer_var_file, common_vars, packerfile, replace_existing, vmServer=None, prependString = "", factory_image = false):
     TEMP_DIR="tmp"
 
     vm_name = packer_var_file.strip(".json")
@@ -103,20 +103,18 @@ def main(argv):
         if opt in ("-h", "--help"):
             print argv[0] + " [options]"
             print '-c <file>, --esxiConfig=<file>       use alternate hypervisor config file'
-            print '-f, --factory                   builds system without additional packages'
+            print '-f, --factory                        builds system without additional packages'
             print '-p <string>, --prependString=<file>  prepend string to the beginning of VM names'
             print '-r, --replace                        replace existing msf_host'
             sys.exit()
         elif opt in ("-c", "--esxiConfig"):
             esxi_file = arg
         elif opt in ("-f", "--factory"):
-            factory_image = True # Equivolent to noSoftware. -ns was not a valid short flag with getopt.
+            factory_image = True # Build with minimum required software, users and vm tools.
         elif opt in ("-p", "--prependString"):
             prependString = arg
         elif opt in ("-r", "--replace"):
             replace_vms = True
-
-        
 
     vm_server = serverHelper(esxi_file)
 
@@ -137,7 +135,7 @@ def main(argv):
 
             print "\nBuilding " + str(len(targets)) + " " + os_dir.capitalize() + " baselines:"
             for target in tqdm(targets):
-                build_base(target, common_vars, packer_file, factory_image, replace_existing=replace_vms, vmServer=vm_server, prependString=prependString)
+                build_base(target, common_vars, packer_file, replace_existing=replace_vms, vmServer=vm_server, prependString=prependString, factory_iamge)
 
             os.chdir("../")
 


### PR DESCRIPTION
##description
-Updated the `getopt` arguments to properly parse long args
-added `-f` and `--factory` short/long args for clean factory build for ubuntu 14.04 -> 18.04

##testing
- [ ] Run `$ build_linux_baselines.py -f`
- [ ] **Verify** that the ubuntu 14.04, 16.04 and 18.04 servers images build correctly without running `custom_script.sh`
- [ ] Run `$ build_baselines.py -f`
- [ ] **Verify** that the desired Windows hosts build correctly without `ruby`, `java` or `python`