### PR TITLE
enable tls12 for vagrant key download

### DIFF
--- a/scripts/configs/vagrant-ssh.bat
+++ b/scripts/configs/vagrant-ssh.bat
@@ -1,6 +1,0 @@
-:: vagrant public key
-if exist a:\vagrant.pub (
-  copy a:\vagrant.pub C:\Users\vagrant\.ssh\authorized_keys
-) else (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')" <NUL
-)

--- a/scripts/configs/vagrant-ssh.ps1
+++ b/scripts/configs/vagrant-ssh.ps1
@@ -1,0 +1,56 @@
+function Invoke-CLR4PowerShellCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ScriptBlock]
+        $ScriptBlock,
+        
+        [Parameter(ValueFromRemainingArguments=$true)]
+        [Alias('Args')]
+        [object[]]
+        $ArgumentList
+    )
+    
+    if ($PSVersionTable.CLRVersion.Major -eq 4) {
+        Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
+        return
+    }
+
+    $RunActivationConfigPath = $Env:TEMP | Join-Path -ChildPath ([Guid]::NewGuid())
+    New-Item -Path $RunActivationConfigPath -ItemType Container | Out-Null
+@"
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0"/>
+  </startup>
+</configuration>
+"@ | Set-Content -Path $RunActivationConfigPath\powershell.exe.activation_config -Encoding UTF8
+
+    $EnvVarName = 'COMPLUS_ApplicationMigrationRuntimeActivationConfigPath'
+    $EnvVarOld = [Environment]::GetEnvironmentVariable($EnvVarName)
+    [Environment]::SetEnvironmentVariable($EnvVarName, $RunActivationConfigPath)
+
+    try {
+        & powershell.exe -inputformat text -command $ScriptBlock -args $ArgumentList
+    } finally {
+        [Environment]::SetEnvironmentVariable($EnvVarName, $EnvVarOld)
+        $RunActivationConfigPath | Remove-Item -Recurse
+    }
+
+}
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$isWin8 = wmic os get caption | find /i '" 8 "'
+$isWin2012 = wmic os get caption | find /i '" 2012 "'
+
+# skip wrapping for 8 or 2012?
+if ($isWin8 -or $isWin2012){
+   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')
+}else{
+    Invoke-CLR4PowerShellCommand -ScriptBlock {
+       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub', 'C:\Users\vagrant\.ssh\authorized_keys')
+    }
+}

--- a/windows_packer.json
+++ b/windows_packer.json
@@ -115,7 +115,6 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "scripts": [
         "./scripts/configs/update_root_certs.bat",
-        "./scripts/configs/vagrant-ssh.bat",
         "./scripts/configs/disable-auto-logon.bat",
         "./scripts/configs/enable-rdp.bat"
       ]
@@ -134,6 +133,7 @@
     {
       "type":"powershell",
       "scripts": [
+        "./scripts/configs/vagrant-ssh.ps1",
         "./scripts/installs/chocolatey.ps1"
       ]
     },


### PR DESCRIPTION
Similar to #51, more resources requiring `Tls1.2` that need special wrapping on older OS versions.