### PR TITLE
vm-tools step already has 7z

### DIFF
--- a/scripts/installs/vm-guest-tools.bat
+++ b/scripts/installs/vm-guest-tools.bat
@@ -1,16 +1,5 @@
 reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
 
-if %OS%==32BIT (
-    if not exist "C:\Windows\Temp\7z1801.msi" (
-        powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://www.7-zip.org/a/7z1801.msi', 'C:\Windows\Temp\7z1801.msi')" <NUL
-    )
-)
-if %OS%==64BIT echo This is a 64bit operating system
-    if not exist "C:\Windows\Temp\7z1801.msi" (
-        powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://www.7-zip.org/a/7z1801-x64.msi', 'C:\Windows\Temp\7z1801.msi')" <NUL
-    )
-msiexec /qb /i C:\Windows\Temp\7z1801.msi
-
 wmic os get caption | find /i "7" > NUL && set TOOLS_VER=OLD || set TOOLS_VER=NEW
 
 if %TOOLS_VER%==NEW (
@@ -39,4 +28,3 @@ cmd /c C:\Windows\Temp\VMWare\setup.exe /S /v "/qn /l*v ""%TEMP%\vmmsi.log"" REB
 
 :done
 
-msiexec /qb /x C:\Windows\Temp\7z1801.msi


### PR DESCRIPTION
The 7z download location has become problematic, however 7z is
already installed earlier in the process. This change simply removes
the attempts to get 7z during vm-tools install.